### PR TITLE
Add pymongo4 compatibility

### DIFF
--- a/mongodb_proxy.py
+++ b/mongodb_proxy.py
@@ -83,7 +83,7 @@ class MongoProxy:
         Otherwise just return the attribute.
         """
         item = self.proxied_object[key]
-        if hasattr(item, '__call__'):
+        if hasattr(item, '__call__') or isinstance(item, pymongo.database.Database):
             return MongoProxy(item, self.wait_time)
         return item
 
@@ -103,7 +103,7 @@ class MongoProxy:
         that handles AutoReconnect exceptions. Otherwise wrap it in a MongoProxy object.
         """
         attr = getattr(self.proxied_object, key)
-        if hasattr(attr, '__call__'):
+        if hasattr(attr, '__call__') or isinstance(attr, pymongo.database.Database):
             attributes_for_class = self.methods_needing_retry.get(self.proxied_object.__class__, [])
             if key in attributes_for_class:
                 return autoretry_read(self.wait_time)(attr)

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def is_requirement(line):
 setup(
     name='openedx-mongodbproxy',
     py_modules=['mongodb_proxy'],
-    version='0.2.0',
+    version='0.2.1',
     description='Proxy around MongoDB connection that automatically handles AutoReconnect exceptions.',
     author='Gustav Arngarden',
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
- `__call__` method has been removed from `pymongo database` class https://github.com/mongodb/mongo-python-driver/pull/542/files#diff-fea5af5b145e4376d3484eb5d647c0fd219bad8f07af1bae72de75ae3c1eba08L1572
- To fix this issue we need to check `Database` class explicitly
