### PR TITLE
Fix: pymongo requires pymongo.collection import

### DIFF
--- a/mongodb_proxy.py
+++ b/mongodb_proxy.py
@@ -17,6 +17,7 @@ Copyright 2013 Gustav Arngarden
 from functools import wraps
 import logging
 import pymongo
+import pymongo.collection
 import time
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
The current version of pymongo doesn't define `pymongo.collection` unless you import it explicitly.